### PR TITLE
Cleanup Mirrors initializer method; improve variable naming

### DIFF
--- a/apt-select.py
+++ b/apt-select.py
@@ -53,14 +53,14 @@ def apt_select():
     parser = get_args()
     args = parser.parse_args()
     flag_number = args.top_number[0]
-    # Convert status argument to format used by Launchpad
-    flag_status = args.min_status[0].replace('-', ' ')
-    if flag_status != 'unknown':
-        flag_status = flag_status[0].upper() + flag_status[1:]
-
+    flag_ping = args.ping_only
     flag_list = args.list_only
     flag_choose = args.choose
-    flag_ping = args.ping_only
+    flag_status = args.min_status[0].replace('-', ' ')
+
+    if not flag_ping and (flag_status != 'unknown'):
+        # Convert status argument to format used by Launchpad
+        flag_status = flag_status[0].upper() + flag_status[1:]
 
     if flag_choose and (not flag_number or flag_number < 2):
         parser.print_usage()
@@ -104,7 +104,7 @@ def apt_select():
     else:
         hardware = 'i386'
 
-    archives = Mirrors(mirrors_list, flag_status)
+    archives = Mirrors(mirrors_list, flag_ping, flag_status)
     archives.get_rtts()
     if archives.got["ping"] < flag_number:
         flag_number = archives.got["ping"]

--- a/mirrors.py
+++ b/mirrors.py
@@ -50,7 +50,7 @@ class DataError(Exception):
 class Mirrors(object):
     """Base for collection of archive mirrors"""
 
-    def __init__(self, url_list, flag_status):
+    def __init__(self, url_list, flag_ping, flag_status):
         self.ranked = []
         self.test_num = len(url_list)
         self.urls = {}
@@ -67,18 +67,19 @@ class Mirrors(object):
             else:
                 self.urls[url] = {"Host": host}
 
-        self.abort_launch = False
-        self.status_opts = (
-            "unknown",
-            "One week behind",
-            "Two days behind",
-            "One day behind",
-            "Up to date"
-        )
-        index = self.status_opts.index(flag_status)
-        self.status_opts = self.status_opts[index:]
-        # Default to top
-        self.status_num = 1
+        if not flag_ping:
+            self.abort_launch = False
+            self.status_opts = (
+                "unknown",
+                "One week behind",
+                "Two days behind",
+                "One day behind",
+                "Up to date"
+            )
+            index = self.status_opts.index(flag_status)
+            self.status_opts = self.status_opts[index:]
+            # Default to top
+            self.status_num = 1
 
     def get_launchpad_urls(self):
         """Obtain mirrors' corresponding launchpad URLs"""


### PR DESCRIPTION
* Only populate status related attributes if the `--ping-only` flag is false.
* Split out thread creation and round trip instantiating into method
* Improve command line flag variable naming