### PR TITLE
Starting main split/refactor, reorder status message

### DIFF
--- a/apt-select.py
+++ b/apt-select.py
@@ -25,13 +25,6 @@ def confirm_mirror(uri):
     return False
 
 
-def assign_defaults(info, keys, default):
-    """Assign a default dict value to key if key is not present"""
-    for key in keys:
-        if key not in info:
-            info[key] = default
-
-
 def ask(query):
     """Ask for unput from user"""
     answer = get_input(query)
@@ -165,7 +158,8 @@ def apt_select():
 
         if not ping_only and not archives.abort_launch:
             if "Status" in info:
-                assign_defaults(info, ("Org", "Speed"), "N/A")
+                for key in ("Org", "Speed"):
+                    info.setdefault(key, "N/A")
                 print((
                     "%(rank)d. %(mirror)s\n%(tab)sLatency: %(ms)d ms\n"
                     "%(tab)sOrg:     %(org)s\n%(tab)sStatus:  %(status)s\n"

--- a/apt-select.py
+++ b/apt-select.py
@@ -61,9 +61,7 @@ def validate_args():
     return args
 
 
-def apt_select():
-    """Run apt-select: Ubuntu archive mirror reporting tool"""
-    args = validate_args()
+def get_release():
     try:
         release = check_output(["lsb_release", "-ics"])
     except OSError:
@@ -75,6 +73,14 @@ def apt_select():
         exit("Debian is not currently supported")
     elif release[0] != 'Ubuntu':
         not_ubuntu()
+
+    return release
+
+
+def apt_select():
+    """Run apt-select: Ubuntu archive mirror reporting tool"""
+    args = validate_args()
+    release = get_release()
 
     directory = '/etc/apt/'
     apt_file = 'sources.list'

--- a/mirrors.py
+++ b/mirrors.py
@@ -122,10 +122,10 @@ class Mirrors(object):
     def get_rtts(self):
         """Test latency to all mirrors"""
 
+        stderr.write("Testing latency to mirror(s)\n")
         self.__kickoff_trips()
 
         processed = 0
-        stderr.write("Testing %d mirror(s)\n" % self.num_trips)
         progress_msg(processed, self.num_trips)
         for _ in range(self.num_trips):
             try:


### PR DESCRIPTION
Split main method into more testable methods.  Validation and release methods added.

Printing out initial test status message before threads are started.