### PR TITLE
Fix #26, consider aborted launch

### DIFF
--- a/apt-select.py
+++ b/apt-select.py
@@ -154,8 +154,8 @@ def apt_select():
 
     rank = 0
     current_key = -1
-    if args.ping_only:
-        archives.top_list = archives.ranked[:args.top_number+1]
+    if args.ping_only or archives.abort_launch:
+        archives.top_list = archives.ranked[:args.top_number]
 
     for url in archives.top_list:
         info = archives.urls[url]


### PR DESCRIPTION
Fixes #26 by assigning the top list if launchpad lookups are aborted.

Also, when building the top list a one-off error for the end index of the ranked slice was fixed.