### PR TITLE
Fix beautiful soup parser error, add utf8 decode method

### DIFF
--- a/apt_system.py
+++ b/apt_system.py
@@ -6,8 +6,8 @@ from utils import utf8_decode
 
 def get_release():
     """Call system for Ubuntu release information"""
-    return (s.strip() for s in utf8_decode(check_output(["lsb_release", "-ics"]))
-            .split())
+    return [s.strip() for s in utf8_decode(check_output(["lsb_release", "-ics"]))
+            .split()]
 
 def get_arch():
     """Return architecture information in Launchpad format"""

--- a/apt_system.py
+++ b/apt_system.py
@@ -2,22 +2,18 @@
 
 from subprocess import check_output
 from os import path
+from utils import utf8_decode
 
 def get_release():
     """Call system for Ubuntu release information"""
-    try:
-        release = check_output(["lsb_release", "-ics"])
-    except OSError as err:
-        raise OSError(err)
-
-    return (s.strip() for s in release.decode('utf-8').split())
+    return (s.strip() for s in utf8_decode(check_output(["lsb_release", "-ics"]))
+            .split())
 
 def get_arch():
     """Return architecture information in Launchpad format"""
-    arch = check_output(["uname", "-m"]).strip().decode('utf-8')
-    if arch == 'x86_64':
-        return 'amd64'
-    return 'i386'
+    if utf8_decode(check_output(["uname", "-m"]).strip()) == u'x86_64':
+        return u'amd64'
+    return u'i386'
 
 
 class AptSystem(object):

--- a/mirrors.py
+++ b/mirrors.py
@@ -35,7 +35,7 @@ else:
     try:
         BeautifulSoup("", PARSER)
     except FeatureNotFound:
-        PARSER = "html.PARSER"
+        PARSER = "html.parser"
 
 try:
     xrange

--- a/utils.py
+++ b/utils.py
@@ -9,6 +9,8 @@ try:
 except ImportError:
     from urllib2 import urlopen, HTTPError, URLError
 
+def utf8_decode(encoded):
+    return encoded.decode('utf-8')
 
 class URLGetError(Exception):
     """Error class for retreiving and reading content from remote URL"""
@@ -27,7 +29,7 @@ def get_html(url):
     except (SSLError, IOError, OSError) as err:
         raise URLGetError(err)
 
-    return html.decode('utf-8')
+    return utf8_decode(html)
 
 
 def progress_msg(processed, total):


### PR DESCRIPTION
* When passing a parser value to `BeautifulSoup`, the string representing the html parser module was in the incorrect format.  Most all Ubuntu users should have the lxml parser library installed by default, but this fixes a bug in cases where it isn't.

* Using list, not generator expression

* Added utf8 decode method

