### PR TITLE
Use const in optional arguments that require value

### DIFF
--- a/apt_select/arguments.py
+++ b/apt_select/arguments.py
@@ -22,6 +22,7 @@ def get_args():
             "specify number of mirrors to return\n"
             "default: 1\n"
         ),
+        const=1,
         default=1,
         metavar='NUMBER'
     )
@@ -55,6 +56,7 @@ def get_args():
                 'unknown': status_args[4]
             }
         ),
+        const=status_args[0],
         default=status_args[0],
         metavar='STATUS'
     )


### PR DESCRIPTION
This fixes #49 to store values for empty command line optional arguments.