### PR TITLE
Add support for KDE neon

### DIFF
--- a/apt_select/apt_system.py
+++ b/apt_select/apt_system.py
@@ -36,7 +36,8 @@ class AptSystem(object):
     else:
         codename = codename.capitalize()
 
-    if dist != 'Ubuntu':
+    # KDE neon is based on Ubuntu but does not report itself as such
+    if dist not in ['Ubuntu', 'neon']:
         raise ValueError(_not_ubuntu)
 
     arch = get_arch.__func__()


### PR DESCRIPTION
When running `apt-select` in KDE neon you get a `"Must be an Ubuntu OS"` error.
KDE neon is based on Ubuntu LTS but there doesn't seem to be a standard way to tell from the CLI.

```
$ cat /etc/issue
KDE neon 5.9 \n \l

$ lsb_release -a
Distributor ID: neon
Description:    KDE neon User Edition 5.9
Release:        16.04
Codename:       xenial
```
There is a hint in the kernel version name:
```
$ uname -v
#88-Ubuntu SMP Wed Mar 8 16:34:45 UTC 2017
```
But I have doubts on how reliable that info is.

Thus I added a check against `'neon'` in the code.