### PR TITLE
Exit 0 on success

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,6 +72,9 @@ Invocation
       -l, --list            print list of mirrors only, don't generate file
                             cannot be used with -c/--choose
 
+    The exit code is 0 on success, 1 on error, and 4 if sources.list already has the chosen
+    mirror and a new one was not generated.
+
 Examples
 --------
 

--- a/apt_select/__main__.py
+++ b/apt_select/__main__.py
@@ -6,7 +6,7 @@ import re
 
 from sys import exit, stderr, version_info
 from os import getcwd
-from apt_select.arguments import get_args, DEFAULT_COUNTRY
+from apt_select.arguments import get_args, DEFAULT_COUNTRY, SKIPPED_FILE_GENERATION
 from apt_select.mirrors import Mirrors
 from apt_select.apt import System, Sources, SourcesFileError
 from apt_select.utils import DEFAULT_REQUEST_HEADERS
@@ -207,12 +207,13 @@ def apt_select():
     new_mirror = archives.top_list[key]
     print("Selecting mirror %(mirror)s ..." % {'mirror': new_mirror})
     if current_url == new_mirror:
-        exit((
+        stderr.write(
             "%(url)s is the currently used mirror.\n"
-            "%(message)s" % {
+            "%(message)s\n" % {
                 'url': current_url,
                 'message': sources.skip_gen_msg
-            }))
+            })
+        exit(SKIPPED_FILE_GENERATION)
 
     work_dir = getcwd()
     if work_dir == sources.DIRECTORY[0:-1]:

--- a/apt_select/arguments.py
+++ b/apt_select/arguments.py
@@ -12,6 +12,7 @@ STATUS_ARGS = (
     "one-week-behind",
     "unknown"
 )
+SKIPPED_FILE_GENERATION = 4
 
 def get_args():
     """Get parsed command line arguments"""
@@ -20,6 +21,9 @@ def get_args():
             "Find the fastest Ubuntu apt mirrors.\n"
             "Generate new sources.list file."
         ),
+        epilog="The exit code is 0 on success, 1 on error, and %d if "\
+        "sources.list already has the chosen\n"\
+        "mirror and a new one was not generated." % SKIPPED_FILE_GENERATION,
         formatter_class=RawTextHelpFormatter
     )
     parser.add_argument(


### PR DESCRIPTION
If the script succeeds, but selects the currently used mirror, the
current version returns 1. This is the same exit code used for actual
errors, like network problems, invalid input etc. This makes it
impossible for callers to know whether an actual error occurred or not.

Instead we now return 0 in this case.

---

Note: I'm open to returning non-zero in this case as well, if you think that's better. But then we should return something else than 1, so the caller can detect it. I also think we should document the exit codes. Here's for instance how `man grep` does that:
> EXIT STATUS
       Normally the exit status is 0 if a line is selected, 1 if no lines were selected, and 2 if an error occurred.  However, if the -q or --quiet or --silent is used and a  line  is  selected,  the  exit
       status is 0 even if an error occurred.
