### PR TITLE
Handle http errors consistently

### DIFF
--- a/apt_select/mirrors.py
+++ b/apt_select/mirrors.py
@@ -76,7 +76,7 @@ class Mirrors(object):
         except URLGetTextError as err:
             stderr.write((
                 "%s: %s\nUnable to retrieve list of launchpad sites\n"
-                "Reverting to latency only" % (self._launchpad_url, err)
+                "Reverting to latency only\n" % (self._launchpad_url, err)
             ))
             self.abort_launch = True
         else:

--- a/apt_select/utils.py
+++ b/apt_select/utils.py
@@ -22,11 +22,12 @@ class URLGetTextError(Exception):
 def get_text(url):
     """Return text from GET request response content"""
     try:
-        text = requests.get(url, headers=DEFAULT_REQUEST_HEADERS).text
+        result = requests.get(url, headers=DEFAULT_REQUEST_HEADERS)
+        result.raise_for_status()
     except requests.HTTPError as err:
         raise URLGetTextError(err)
 
-    return text
+    return result.text
 
 
 def progress_msg(processed, total):


### PR DESCRIPTION
Previously, if launchpad.net returned an http error code, this would not
be detected by get_text(). Instead the program would continue, and
eventually crash with an AttributeError when using the output from
BeautifulSoup.

This commit checks the status code of the http request, and fails if it
is not 200 OK, in the same way as if we got an HTTPError.

This makes sure we get the same behavior in all cases of http failures,
and the error message is a lot nicer.

New behavior:

> Getting list of launchpad
> URLs...https://launchpad.net/uuntu/+archivemirrors: Failed to fetch
> mirror list: status code 404
> Unable to retrieve list of launchpad sites
> Reverting to latency only1. ny-mirrors.evowise.com: 1.35 ms
> (program continues)

Old behavior:

> Traceback (most recent call last):
>   (stack trace redacted)
> AttributeError: 'NoneType' object has no attribute 'descendants'
> (program exits)

To test this, put a wrong url in mirrors.py:55