### PR TITLE
Add random flag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,6 +71,8 @@ Invocation
                             requires -t/--top-num NUMBER where NUMBER > 1
       -l, --list            print list of mirrors only, don't generate file
                             cannot be used with -c/--choose
+      -r, --random          pick a random mirror from top list
+                            cannot be used with -c/--choose
 
     The exit code is 0 on success, 1 on error, and 4 if sources.list already has the chosen
     mirror and a new one was not generated.

--- a/apt_select/__main__.py
+++ b/apt_select/__main__.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """Main apt-select script"""
 
+import random
 import requests
 import re
 
@@ -200,6 +201,8 @@ def apt_select():
     key = 0
     if args.choose:
         key = get_selected_mirror(len(archives.top_list)) - 1
+    elif args.random:
+        key = random.randint(0, len(archives.top_list) - 1)
 
     if args.list_only:
         exit()

--- a/apt_select/apt.py
+++ b/apt_select/apt.py
@@ -157,6 +157,9 @@ class Sources(object):
             raise SourcesFileError(err)
 
         urls = self.__get_current_archives()
+        if 'current' not in urls:
+            # hardcode a fallback to main ubuntu archive
+            urls['current'] = 'http://archive.ubuntu.com/ubuntu'
         if not urls:
             raise SourcesFileError((
                 "Error finding current %s URI in %s\n%s\n" %

--- a/apt_select/apt.py
+++ b/apt_select/apt.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from subprocess import check_output
-from os import path
+from os import path, environ
 from apt_select.utils import utf8_decode
 
 SUPPORTED_KERNEL = 'Linux'
@@ -97,7 +97,7 @@ class Sources(object):
 
     DIRECTORY = '/etc/apt/'
     LIST_FILE = 'sources.list'
-    _CONFIG_PATH = DIRECTORY + LIST_FILE
+    _CONFIG_PATH = environ.get('APT_CONFIGPATH', DIRECTORY + LIST_FILE)
 
     def __init__(self, codename):
         self._codename = codename.lower()

--- a/apt_select/arguments.py
+++ b/apt_select/arguments.py
@@ -112,6 +112,17 @@ def get_args():
         ),
         default=False
     )
+    output_group.add_argument(
+        '-r',
+        '--random',
+        dest='random',
+        action='store_true',
+        help=(
+            "pick a random mirror from top list\n"
+            "cannot be used with -c/--choose\n"
+        ),
+        default=False
+    )
 
     return parser
 


### PR DESCRIPTION
to randomly select a mirror from the determined list. This should help working around the fact, that even though a mirror is ranked highest it could be still having temporary difficulties.
This can be used in CI systems where interactive --choose flag is not an option